### PR TITLE
fix(writer): Use MCUH cleaner way of finding decimal places to round

### DIFF
--- a/honeybee_idaice/bldgbody.py
+++ b/honeybee_idaice/bldgbody.py
@@ -39,14 +39,14 @@ def _section_to_idm_protected(
         # get the horizontal boundary around the Room geometry
         h_bounds = room.horizontal_floor_boundaries(
             match_walls=False, tolerance=tolerance)
-        clean_h_bounds =  []
+        clean_h_bounds = []
         for h_bound in h_bounds:
             h_bound = h_bound.remove_colinear_vertices(tolerance)
             if h_bound.has_holes:  # remove any tiny holes
                 h_areas = [hp.area for hp in h_bound.hole_polygon2d]
                 if not all(ha > IDA_ICE_BUILDING_BODY_TOL for ha in h_areas):
                     clean_holes = [hole for hole, ha in zip(h_bound.holes, h_areas)
-                                if ha > IDA_ICE_BUILDING_BODY_TOL]
+                                   if ha > IDA_ICE_BUILDING_BODY_TOL]
                     h_bound = Face3D(h_bound.boundary, h_bound.plane, clean_holes)
             clean_h_bounds.append(h_bound)
 
@@ -325,11 +325,13 @@ def _section_to_idm_extruded(
                         btm_vertices = []
                     up_count = len(up_vertices)
                     btm_count = len(btm_vertices)
-                    up_vertices = ' '.join(f'({v[0]} {v[1]} {v[2]})' for v in up_vertices)
-                    btm_vertices = ' '.join(f'({v[0]} {v[1]} {v[2]})' for v in btm_vertices)
+                    up_vertices = \
+                        ' '.join(f'({v[0]} {v[1]} {v[2]})' for v in up_vertices)
+                    btm_vertices = \
+                        ' '.join(f'({v[0]} {v[1]} {v[2]})' for v in btm_vertices)
 
-                    section = \
-                        f' ((FACE :N "f{identifier}" :T WALL-FACE :INDEX {identifier})\n' \
+                    section = f' (' \
+                        f'(FACE :N "f{identifier}" :T WALL-FACE :INDEX {identifier})\n' \
                         f'  (:PAR :N NCORN :V {up_count})\n' \
                         f'  (:PAR :N CORNERS :V #2A({up_vertices}))\n' \
                         f'  ((FACE :N GROUND-FACE)\n' \

--- a/honeybee_idaice/face.py
+++ b/honeybee_idaice/face.py
@@ -65,9 +65,9 @@ def opening_to_idm(
 
 
 def face_to_idm(
-        face: Face, origin: Point3D, index: int,
-        angle_tolerance: float = 1.0, decimal_places: int = 3
-    ):
+    face: Face, origin: Point3D, index: int,
+    angle_tolerance: float = 1.0, decimal_places: int = 3
+):
     """Translate a HBJSON face to an IDM ENCLOSING-ELEMENT.
 
     Args:
@@ -102,8 +102,10 @@ def face_to_idm(
         contours_formatted = ' '.join(str(len(c)) for c in contours)
 
     dpl = decimal_places
-    vertices_idm = ' '.join((
-        f'({round(v.x - origin.x, dpl)} {round(v.y - origin.y, dpl)} {round(v.z - origin.z, dpl)})'
+    verts_idm = ' '.join((
+        f'({round(v.x - origin.x, dpl)} '
+        f'{round(v.y - origin.y, dpl)} '
+        f'{round(v.z - origin.z, dpl)})'
         for vertices in contours for v in vertices
     ))
 
@@ -132,7 +134,7 @@ def face_to_idm(
 
     face = f'((ENCLOSING-ELEMENT :N "{name}" :T {type_} :INDEX {index})\n' \
         f' ((AGGREGATE :N GEOMETRY)\n' \
-        f'  (:PAR :N CORNERS :DIM ({count} 3) :SP ({count} 3) :V #2A({vertices_idm}))\n' \
+        f'  (:PAR :N CORNERS :DIM ({count} 3) :SP ({count} 3) :V #2A({verts_idm}))\n' \
         f'  (:PAR :N CONTOURS :V ({contours_formatted}))\n' \
         f'  (:PAR :N SLOPE :V {round(face.altitude + 90, 2)})){windows}\n{doors})'
 

--- a/honeybee_idaice/shade.py
+++ b/honeybee_idaice/shade.py
@@ -14,8 +14,8 @@ def _vertices_to_idm(vertices: List[Point3D], dec_places: int = 3) -> str:
 
 
 def _shade_geometry_to_idm(
-        geometry: Union[Face3D, Polyface3D], name: str, decimal_places: int = 3
-    ):
+    geometry: Union[Face3D, Polyface3D], name: str, decimal_places: int = 3
+):
     """Create an IDM shade block from a Ladybug geometry.
 
     Here is an example:
@@ -26,13 +26,13 @@ def _shade_geometry_to_idm(
             (:PAR :N SHADOWING :V :TRUE)
             ((AGGREGATE :N "geom1" :T GEOM3D)
             (:PAR :N NPOINTS :V 4)
-            (:PAR :N POINTS :DIM (4 3) :V #2A((-0.874454021453857 -0.59070497751236 -0.941487014293671) (1.0536140203476 -0.0591499991714954 -0.941487014293671) (-1.0536140203476 0.0591499991714954 0.941487014293671) (0.874454021453857 0.59070497751236 0.941487014293671)))
+            (:PAR :N POINTS :DIM (4 3) :V #2A((-0.874 -0.59 -0.941) (1.054 -0.059 -0.941) (-1.054 0.06 0.941) (0.874 0.59 0.941)))
             (:PAR :N CELLTYPE :V 1)
             (:PAR :N NCELLS :V 2)
             (:PAR :N NVERTICES :DIM (2) :V #(3 3))
             (:PAR :N TOTNVERTS :V 6)
             (:PAR :N VERTICES :DIM (6) :V #(0 1 2 2 1 3))
-        (:PAR :N PROPERTY :V #(1.0 1.0 1.0 0.699999988079071 1.0 1.0 1.0 0.5 1.0 1.0 1.0 0.0 1.0 1.0 1.0 0.0 0.0))))
+        (:PAR :N PROPERTY :V #(1.0 1.0 1.0 0.7 1.0 1.0 1.0 0.5 1.0 1.0 1.0 0.0 1.0 1.0 1.0 0.0 0.0))))
     """
 
     if isinstance(geometry, Face3D):
@@ -51,12 +51,13 @@ def _shade_geometry_to_idm(
     faces_count = ' '.join(str(f) for f in face_length)
     joined_faces = ' '.join(' '.join(str(f) for f in ff) for ff in faces)
 
+    shd_verts = _vertices_to_idm(vertices, decimal_places)
     shade = f' ((AGGREGATE :N "{name}" :T PICT3D)\n' \
         '  (:PAR :N FILE :V "")\n' \
         '  (:PAR :N SHADOWING :V :TRUE)\n' \
         '  ((AGGREGATE :N "geom1" :T GEOM3D)\n' \
         f'   (:PAR :N NPOINTS :V {vertices_count})\n' \
-        f'   (:PAR :N POINTS :DIM ({vertices_count} 3) :V #2A({_vertices_to_idm(vertices, decimal_places)}))\n' \
+        f'   (:PAR :N POINTS :DIM ({vertices_count} 3) :V #2A({shd_verts}))\n' \
         '   (:PAR :N CELLTYPE :V 1)\n' \
         f'   (:PAR :N NCELLS :V {face_count})\n' \
         f'   (:PAR :N NVERTICES :DIM ({face_count}) :V #({faces_count}))\n' \
@@ -68,8 +69,8 @@ def _shade_geometry_to_idm(
 
 
 def _shade_group_to_idm(
-        shades: List[Shade], tolerance: float, decimal_places: int = 3
-    ) -> str:
+    shades: List[Shade], tolerance: float, decimal_places: int = 3
+) -> str:
     """Convert a group of shades into a IDM string.
 
     The files in the shade group should create a closed volume. The translator uses


### PR DESCRIPTION
I just discovered this one line of Python I can use to replace the ~15 lines of garbage code I wrote earlier. And it works for all tolerance values. Even those above 1. I think I'm going to use this everywhere now.

I'm also taking the opportunity to clean up a lot of PEP8 stuff.